### PR TITLE
Modify appwrapper to prevent multiple logins

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2,3 +2,7 @@
 body {
   margin: auto;
 }
+
+.notification {
+  color: yellowgreen;
+}

--- a/src/AppWrapper.jsx
+++ b/src/AppWrapper.jsx
@@ -19,6 +19,12 @@ const AppWrapper = ({ children }) => {
   }, [location.pathname, token]);
 
   useEffect(() => {
+    if (token && isLoginOrSignupPath(location.pathname)) {
+      navigate('/dummyHome');
+    }
+  }, [location.pathname, navigate, token]);
+
+  useEffect(() => {
     if (token) {
       const tokenTimeout = setTimeout(() => {
         dispatch(clearToken());


### PR DESCRIPTION
Added a function to prevent access to the login, signup and splash page if a user is already logged in (i.e a session token exists)